### PR TITLE
Remove formatting placeholder from fmt.Println

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -30,7 +30,7 @@ func main() {
 	// get a new connection from pool
 	conn, err := p.Get()
 	if err != nil {
-		fmt.Println("Get error: %s", err)
+		fmt.Println("Get error:", err)
 	}
 
 	_, ok := conn.(*gpool.GConn)


### PR DESCRIPTION
When testing Go would show this warning:

`example/example.go:33: Println call has possible formatting directive %s`