### PR TITLE
Blocking Get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Intellij
+*.iml
+.idea/

--- a/conn.go
+++ b/conn.go
@@ -24,6 +24,7 @@ func (g *GConn) Close() error {
 
 	if g.unusable {
 		if g.Conn != nil {
+			g.p.addRemainingSpace()
 			return g.Conn.Close()
 		}
 		return nil

--- a/pool.go
+++ b/pool.go
@@ -23,4 +23,6 @@ type Pool interface {
 
 	// Idle get the idle connection pool number
 	Idle() int
+
+	BlockingGet() (net.Conn, error)
 }


### PR DESCRIPTION
Took a stab at implementing BlockingGet in the pool. Using new ```p.BlockingGet()``` to get a connection from pool will cause block if there are no idle connections and MaxCap is reached.

Let me know what you think.