### PR TITLE
fixed wrong removal of remainingspace in BlockingGet()

### DIFF
--- a/gpool.go
+++ b/gpool.go
@@ -182,12 +182,7 @@ func (p *gPool) BlockingGet() (net.Conn, error) {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		p.createNum++
-		//if p.createNum > p.poolConfig.MaxCap {
-		//	return nil, errors.New("More than MaxCap")
-		//}
 		conn, err := factory()
-		p.removeRemainingSpace()
-
 		if err != nil {
 			p.addRemainingSpace()
 			return nil, err


### PR DESCRIPTION
Fixes #3 
This  `p.removeRemainingSpace()` was wrong, causing the pool to not reach the maxcap due to request.

Also removed unnecessary comments.