### PR TITLE
Optional Timeout for BlockingGet()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gpool[![GoDoc](http://godoc.org/github.com/silenceper/pool?status.svg)](http://godoc.org/github.com/silenceper/pool) [![Build Status](https://travis-ci.org/Broadroad/gpool.svg?branch=master)](https://travis-ci.org/Broadroad/gpool)
+# gpool[![GoDoc](http://godoc.org/github.com/silenceper/pool?status.svg)](http://godoc.org/github.com/silenceper/pool) [![Build Status](http://img.shields.io/travis/fatih/pool.svg?style=flat-square)](https://travis-ci.org/Broadroad/gpool)
 
 A go tcp connection pool
 
@@ -61,7 +61,7 @@ p.Close()
 ```
 
 ## License
-The Apache License 2.0 - see LICENCE for more details
+The Apache License 2.0 - see LISENCE for more details
 
 ## Issue
 It will be very pleasure if you give some issue or pr. Feel free to contact tjbroadroad@163.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gpool[![GoDoc](http://godoc.org/github.com/silenceper/pool?status.svg)](http://godoc.org/github.com/silenceper/pool) [![Build Status](http://img.shields.io/travis/fatih/pool.svg?style=flat-square)](https://travis-ci.org/Broadroad/gpool)
+# gpool[![GoDoc](http://godoc.org/github.com/silenceper/pool?status.svg)](http://godoc.org/github.com/silenceper/pool) [![Build Status](https://travis-ci.org/Broadroad/gpool.svg?branch=master)](https://travis-ci.org/Broadroad/gpool)
 
 A go tcp connection pool
 
@@ -61,7 +61,7 @@ p.Close()
 ```
 
 ## License
-The Apache License 2.0 - see LISENCE for more details
+The Apache License 2.0 - see LICENCE for more details
 
 ## Issue
 It will be very pleasure if you give some issue or pr. Feel free to contact tjbroadroad@163.com

--- a/gpool.go
+++ b/gpool.go
@@ -182,12 +182,7 @@ func (p *gPool) BlockingGet() (net.Conn, error) {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		p.createNum++
-		//if p.createNum > p.poolConfig.MaxCap {
-		//	return nil, errors.New("More than MaxCap")
-		//}
 		conn, err := factory()
-		p.removeRemainingSpace()
-
 		if err != nil {
 			p.addRemainingSpace()
 			return nil, err

--- a/gpool.go
+++ b/gpool.go
@@ -182,7 +182,12 @@ func (p *gPool) BlockingGet() (net.Conn, error) {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		p.createNum++
+		//if p.createNum > p.poolConfig.MaxCap {
+		//	return nil, errors.New("More than MaxCap")
+		//}
 		conn, err := factory()
+		p.removeRemainingSpace()
+
 		if err != nil {
 			p.addRemainingSpace()
 			return nil, err

--- a/gpool_test.go
+++ b/gpool_test.go
@@ -1,6 +1,7 @@
 package gpool
 
 import (
+	"context"
 	"log"
 	"net"
 	"testing"
@@ -81,13 +82,18 @@ func TestBlockingGet(t *testing.T) {
 	defer p.Close()
 	done := make(chan struct{})
 
+	//todo: test nil ctx, ctx with and without timeout
+	//context
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	for i := 0; i < 30; i++ {
 		go func(i int) {
 			defer func() {
 				done <- struct{}{}
 			}()
 
-			conn, err := p.BlockingGet()
+			conn, err := p.BlockingGet(ctx)
 			if err != nil {
 				t.Errorf("Get error: %s", err)
 			}

--- a/pool.go
+++ b/pool.go
@@ -2,6 +2,7 @@
 package gpool
 
 import (
+	"context"
 	"errors"
 	"net"
 )
@@ -25,6 +26,8 @@ type Pool interface {
 	// Idle get the idle connection pool number
 	Idle() int
 
-	// BlockingGet will block until it get a idle connection from pool
-	BlockingGet() (net.Conn, error)
+	// BlockingGet will block until it gets an idle connection from pool. Context timeout can be passed with context
+	// to wait for specific amount of time. If nil is passed, this will wait indefinitely until a connection is
+	// available.
+	BlockingGet(context.Context) (net.Conn, error)
 }


### PR DESCRIPTION
Using context package we can now set timeout for the `BlockingGet()`.
`BlockingGet` from now on will require an argument which can be `context.Context` or `nil`.
If we pass `context` with no timeout or `nil` to `BlockingGet` it will block indefinitely.

Sample:
```
        ...
	// factory is the function that create connection
	factory := func() (net.Conn, error) {
		return net.Dial("tcp", "127.0.0.1:3333")
	}

	// poolConfig is the config of gpool
	poolConfig := &gpool.PoolConfig{
		InitCap: 2,
		MaxCap:  4,
		Factory: factory,
	}

	// create a new conn pool
	p, err := gpool.NewGPool(poolConfig)
	if err != nil {
		fmt.Println("new pool error is", err)
	}
	fmt.Println("creation:", p.Len(), p.Idle())

	// release pool
	defer p.Close()
	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second) //3second timeout
	defer cancel()
	// get a new connection from pool
	for i := 0; i < 23; i++ {
		go func() {
			conn, err := p.BlockingGet(ctx)
			if err != nil {
				fmt.Println("Get error:", err)
				return
			}
			gConn, ok := conn.(*gpool.GConn)
			if !ok {
				fmt.Println("not gConn")
				return
                        }
			defer gConn.Close()
			if err != nil {
				fmt.Println(err)
			} else {
				gConn.Write([]byte("message"))
				time.Sleep(time.Second * 8)
			}
		}()
	}
        time.Sleep(time.Second * 30)
        ...

```

